### PR TITLE
Update configuration.h to make more pro friendly

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -110,7 +110,7 @@
 
 // Optional custom name for your RepStrap or other custom machine
 // Displayed in the LCD "Ready" message
-#define CUSTOM_MACHINE_NAME "BigBox 1.1 D"
+#define CUSTOM_MACHINE_NAME "BigBox 1.1 P"
 
 // Define this to set a unique identifier for this printer, (Used by some programs to differentiate between machines)
 // You can use an online service to generate a random UUID. (eg http://www.uuidgenerator.net/version4)
@@ -118,7 +118,7 @@
 
 // This defines the number of extruders
 // :[1,2,3,4]
-#define EXTRUDERS 2
+#define EXTRUDERS 1
 
 // Offset of the extruders (uncomment if using more than one and relying on firmware to position when changing).
 // The offset has to be X=0, Y=0 for the extruder 0 hotend (default extruder).
@@ -484,7 +484,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define INVERT_E3_DIR false
 
 // @section homing
-//#define MIN_Z_HEIGHT_FOR_HOMING 4 // (in mm) Minimal z height before homing (G28) for Z clearance above the bed, clamps, ...
+#define MIN_Z_HEIGHT_FOR_HOMING 4 // (in mm) Minimal z height before homing (G28) for Z clearance above the bed, clamps, ...
                                     // Be sure you have this distance over your Z_MAX_POS in case.
 
 // ENDSTOP SETTINGS:
@@ -500,7 +500,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // @section machine
 
 // Travel limits after homing (units are in mm)
-#define X_MIN_POS -38 // -38 for Dual, 0 for Pro
+#define X_MIN_POS 0 // -38 for Dual, 0 for Pro
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0
 #define X_MAX_POS 300


### PR DESCRIPTION
Make a few adjustments to make the Pro branch more Pro friends, fixes to number of extruders, X Min position, Machine name and re-enable the bed drop before homing (otherwise it is impossible to use autohome if the bed is too close to Z home and has already triggered the sensor)
